### PR TITLE
Issue 5 - make configuration consistency mandatory for addresses and ports

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -273,6 +273,7 @@ func validateConfiguration() {
 
 	shared.AssertParamPort("api port", ClientConfiguration.APIPort)
 
+	shared.AssertParamHostsDifferent("hosts", ClientConfiguration.GatewayHost, ClientConfiguration.ListenHost)
 	shared.AssertParamPortsDifferent("ports", ClientConfiguration.GatewayPort,
 		ClientConfiguration.ListenPort, ClientConfiguration.APIPort)
 

--- a/client/client.go
+++ b/client/client.go
@@ -62,9 +62,7 @@ func RunClient(ctx context.Context, cancel context.CancelFunc) {
 	log.Println("Starting TCP-QPEP Tunnel Listener")
 
 	// update configuration from flags
-	if err := validateConfiguration(); err != nil {
-
-	}
+	validateConfiguration()
 
 	log.Printf("Binding to TCP %s:%d", ClientConfiguration.ListenHost, ClientConfiguration.ListenPort)
 	var err error
@@ -255,7 +253,7 @@ func apiStatusCheck() {
 	log.Printf("Gateway Echo FAILED\n")
 }
 
-func validateConfiguration() error {
+func validateConfiguration() {
 	// copy values for client configuration
 	ClientConfiguration.GatewayHost = shared.QuicConfiguration.GatewayIP
 	ClientConfiguration.GatewayPort = shared.QuicConfiguration.GatewayPort
@@ -280,5 +278,4 @@ func validateConfiguration() error {
 
 	// validation ok
 	log.Printf("Client configuration validation OK\n")
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -49,13 +49,13 @@ func main() {
 	interruptListener := make(chan os.Signal, 1)
 	signal.Notify(interruptListener, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
-CHECKLOOP:
+TERMINATIONLOOP:
 	for {
 		select {
 		case <-interruptListener:
-			break CHECKLOOP
+			break TERMINATIONLOOP
 		case <-execContext.Done():
-			break CHECKLOOP
+			break TERMINATIONLOOP
 		case <-time.After(100 * time.Millisecond):
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -41,17 +41,27 @@ func main() {
 	execContext, cancelExecutionFunc := context.WithCancel(context.Background())
 
 	if shared.QuicConfiguration.ClientFlag {
-		runAsClient(execContext)
+		runAsClient(execContext, cancelExecutionFunc)
 	} else {
-		runAsServer(execContext)
+		runAsServer(execContext, cancelExecutionFunc)
 	}
 
-	interruptListener := make(chan os.Signal)
+	interruptListener := make(chan os.Signal, 1)
 	signal.Notify(interruptListener, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	<-interruptListener
+
+CHECKLOOP:
+	for {
+		select {
+		case <-interruptListener:
+			break CHECKLOOP
+		case <-execContext.Done():
+			break CHECKLOOP
+		case <-time.After(100 * time.Millisecond):
+			continue
+		}
+	}
 
 	cancelExecutionFunc()
-
 	<-execContext.Done()
 
 	log.Println("Shutdown...")
@@ -63,7 +73,7 @@ func main() {
 	os.Exit(1)
 }
 
-func runAsClient(execContext context.Context) {
+func runAsClient(execContext context.Context, cancel context.CancelFunc) {
 	log.Println("Running Client")
 
 	windivert.EnableDiverterLogging(shared.QuicConfiguration.Verbose)
@@ -81,11 +91,11 @@ func runAsClient(execContext context.Context) {
 		os.Exit(1)
 	}
 
-	go client.RunClient(execContext)
+	go client.RunClient(execContext, cancel)
 }
 
-func runAsServer(execContext context.Context) {
+func runAsServer(execContext context.Context, cancel context.CancelFunc) {
 	log.Println("Running Server")
-	go server.RunServer(execContext)
-	go api.RunAPIServer(execContext)
+	go server.RunServer(execContext, cancel)
+	go api.RunServer(execContext, cancel)
 }

--- a/qpep-tray/client_handler.go
+++ b/qpep-tray/client_handler.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"os/exec"
+
+	"github.com/parvit/qpep/shared"
 )
 
 var clientCmd *exec.Cmd
@@ -10,7 +12,7 @@ var clientCmd *exec.Cmd
 func startClient() error {
 	if clientCmd != nil {
 		log.Println("ERROR: Cannot start an already running client, first stop it")
-		return ErrFailed
+		return shared.ErrFailed
 	}
 
 	clientCmd = getClientCommand()
@@ -18,7 +20,7 @@ func startClient() error {
 	if err := clientCmd.Start(); err != nil {
 		ErrorMsg("Could not start client program: %v", err)
 		clientCmd = nil
-		return ErrCommandNotStarted
+		return shared.ErrCommandNotStarted
 	}
 	InfoMsg("Client started")
 

--- a/qpep-tray/common.go
+++ b/qpep-tray/common.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"runtime/debug"
@@ -19,12 +18,6 @@ const (
 	TooltipMsgDisconnected = "QPep TCP accelerator - Status: Disconnected"
 	TooltipMsgConnecting   = "QPep TCP accelerator - Status: Connecting"
 	TooltipMsgConnected    = "QPep TCP accelerator - Status: Connected"
-)
-
-var (
-	ErrFailed            = errors.New("failed")
-	ErrNoCommand         = errors.New("could not create command")
-	ErrCommandNotStarted = errors.New("could not start command")
 )
 
 func ErrorMsg(message string, parameters ...interface{}) {

--- a/qpep-tray/impl_linux.go
+++ b/qpep-tray/impl_linux.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/parvit/qpep/shared"
 )
 
 const (
@@ -95,13 +97,13 @@ func stopProcess(pid int) error {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		ErrorMsg("Could not terminate client process: %v", err)
-		return ErrFailed
+		return shared.ErrFailed
 	}
 
 	log.Println("Waiting for client exe to terminate")
 	if err := proc.Signal(syscall.SIGINT); err != nil {
 		ErrorMsg("Could not terminate client process: %v", err)
-		return ErrFailed
+		return shared.ErrFailed
 	}
 
 	return nil

--- a/qpep-tray/impl_windows.go
+++ b/qpep-tray/impl_windows.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/parvit/qpep/shared"
 )
 
 const (
@@ -138,15 +140,15 @@ func stopServerProcess() error {
 func stopProcess(pid int) error {
 	d, e := syscall.LoadDLL("kernel32.dll")
 	if e != nil {
-		return ErrFailed
+		return shared.ErrFailed
 	}
 	p, e := d.FindProc("GenerateConsoleCtrlEvent")
 	if e != nil {
-		return ErrFailed
+		return shared.ErrFailed
 	}
 	r, _, e := p.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
 	if r == 0 {
-		return ErrFailed
+		return shared.ErrFailed
 	}
 
 	return nil

--- a/qpep-tray/server_handler.go
+++ b/qpep-tray/server_handler.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"os/exec"
+
+	"github.com/parvit/qpep/shared"
 )
 
 var serverCmd *exec.Cmd
@@ -10,7 +12,7 @@ var serverCmd *exec.Cmd
 func startServer() error {
 	if serverCmd != nil {
 		log.Println("ERROR: Cannot start an already running server, first stop it")
-		return ErrFailed
+		return shared.ErrFailed
 	}
 
 	serverCmd = getServerCommand()
@@ -18,7 +20,7 @@ func startServer() error {
 	if err := serverCmd.Start(); err != nil {
 		ErrorMsg("Could not start server program: %v", err)
 		serverCmd = nil
-		return ErrCommandNotStarted
+		return shared.ErrCommandNotStarted
 	}
 	InfoMsg("Server started")
 

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,7 @@ type ServerConfig struct {
 	APIPort    int
 }
 
-func RunServer(ctx context.Context) {
+func RunServer(ctx context.Context, cancel context.CancelFunc) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Printf("PANIC: %v", err)
@@ -49,12 +49,14 @@ func RunServer(ctx context.Context) {
 		if quicListener != nil {
 			quicListener.Close()
 		}
+		cancel()
 	}()
 
 	// update configuration from flags
-	ServerConfiguration.ListenHost = shared.QuicConfiguration.ListenIP
-	ServerConfiguration.ListenPort = shared.QuicConfiguration.ListenPort
-	ServerConfiguration.APIPort = shared.QuicConfiguration.GatewayAPIPort
+	if err := validateConfiguration(); err != nil {
+		log.Printf("Invalid configuation provided: %v\n", err)
+		return
+	}
 
 	listenAddr := ServerConfiguration.ListenHost + ":" + strconv.Itoa(ServerConfiguration.ListenPort)
 	log.Printf("Opening QPEP Server on: %s", listenAddr)
@@ -231,4 +233,20 @@ func generateTLSConfig() *tls.Config {
 		Certificates: []tls.Certificate{tlsCert},
 		NextProtos:   []string{"qpep"},
 	}
+}
+
+func validateConfiguration() error {
+	ServerConfiguration.ListenHost = shared.QuicConfiguration.ListenIP
+	ServerConfiguration.ListenPort = shared.QuicConfiguration.ListenPort
+	ServerConfiguration.APIPort = shared.QuicConfiguration.GatewayAPIPort
+
+	shared.AssertParamIP("listen host", ServerConfiguration.ListenHost)
+	shared.AssertParamPort("listen port", ServerConfiguration.ListenPort)
+
+	shared.AssertParamPort("api port", ServerConfiguration.APIPort)
+
+	shared.AssertParamPortsDifferent("ports", ServerConfiguration.ListenPort, ServerConfiguration.APIPort)
+
+	log.Printf("Server configuration validation OK\n")
+	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -53,10 +53,7 @@ func RunServer(ctx context.Context, cancel context.CancelFunc) {
 	}()
 
 	// update configuration from flags
-	if err := validateConfiguration(); err != nil {
-		log.Printf("Invalid configuation provided: %v\n", err)
-		return
-	}
+	validateConfiguration()
 
 	listenAddr := ServerConfiguration.ListenHost + ":" + strconv.Itoa(ServerConfiguration.ListenPort)
 	log.Printf("Opening QPEP Server on: %s", listenAddr)
@@ -235,7 +232,7 @@ func generateTLSConfig() *tls.Config {
 	}
 }
 
-func validateConfiguration() error {
+func validateConfiguration() {
 	ServerConfiguration.ListenHost = shared.QuicConfiguration.ListenIP
 	ServerConfiguration.ListenPort = shared.QuicConfiguration.ListenPort
 	ServerConfiguration.APIPort = shared.QuicConfiguration.GatewayAPIPort
@@ -248,5 +245,4 @@ func validateConfiguration() error {
 	shared.AssertParamPortsDifferent("ports", ServerConfiguration.ListenPort, ServerConfiguration.APIPort)
 
 	log.Printf("Server configuration validation OK\n")
-	return nil
 }

--- a/shared/errors.go
+++ b/shared/errors.go
@@ -1,0 +1,10 @@
+package shared
+
+import "errors"
+
+var (
+	ErrFailed                        = errors.New("failed")
+	ErrNoCommand                     = errors.New("could not create command")
+	ErrCommandNotStarted             = errors.New("could not start command")
+	ErrConfigurationValidationFailed = errors.New("configuration values did not pass validation")
+)

--- a/shared/params_validation.go
+++ b/shared/params_validation.go
@@ -46,3 +46,28 @@ func AssertParamPortsDifferent(name string, values ...int) error {
 
 	return nil
 }
+
+func AssertParamHostsDifferent(name string, values ...string) error {
+	switch len(values) {
+	case 0:
+		fallthrough
+	case 1:
+		return nil
+
+	case 2:
+		if values[0] == values[1] {
+			log.Printf("Addresses '%s' must all be different: %v\n", name, values)
+			panic(ErrConfigurationValidationFailed)
+		}
+	default:
+		sort.Strings(values)
+		for i := 1; i < len(values); i++ {
+			if values[i-1] == values[i] {
+				log.Printf("Addresses '%s' must all be different: %v\n", name, values)
+				panic(ErrConfigurationValidationFailed)
+			}
+		}
+	}
+
+	return nil
+}

--- a/shared/params_validation.go
+++ b/shared/params_validation.go
@@ -1,0 +1,48 @@
+package shared
+
+import (
+	"log"
+	"net"
+	"sort"
+)
+
+func AssertParamIP(name, value string) error {
+	if ip := net.ParseIP(value); ip == nil {
+		log.Printf("Invalid parameter '%s' validated as ip address: %s\n", name, value)
+		panic(ErrConfigurationValidationFailed)
+	}
+	return nil
+}
+
+func AssertParamPort(name string, value int) error {
+	if value < 1 || value > 65536 {
+		log.Printf("Invalid parameter '%s' validated as port [1-65536]: %d\n", name, value)
+		panic(ErrConfigurationValidationFailed)
+	}
+	return nil
+}
+
+func AssertParamPortsDifferent(name string, values ...int) error {
+	switch len(values) {
+	case 0:
+		fallthrough
+	case 1:
+		return nil
+
+	case 2:
+		if values[0] == values[1] {
+			log.Printf("Ports '%s' must all be different: %v\n", name, values)
+			panic(ErrConfigurationValidationFailed)
+		}
+	default:
+		sort.Ints(values)
+		for i := 1; i < len(values); i++ {
+			if values[i-1] == values[i] {
+				log.Printf("Ports '%s' must all be different: %v\n", name, values)
+				panic(ErrConfigurationValidationFailed)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Checks consistency of the commandline parameters before trying to start the servers / clients so that there is less of a chance of executing with wrong values.

The checks at the moment are:
* _server_ : 
  * Listen host must be a valid ip address
  * Listen port must be a valid port [1,65536]
  * API port must be a valid port [1,65536]
  * Listen port and API port must be different

* _client_ : 
  * Gateway host must be a valid ip address
  * Gateway port must be a valid port [1,65536]
  * Listen host must be a valid ip address
  * Listen port must be a valid port [1,65536]
  * API port must be a valid port [1,65536]
  * Listen port and API port must be different
  * Gateway host and Listen host must be different

If any of these conditions are not met than the server / client automatically terminates forcing the user to reevaluate their choice of parameters, the wrong value is also indicated clearly in the log, for example:
```
$ .\qpep.exe -apiport 0
2022/07/30 22:15:56 Server statistics reset.
22:15:56.478267 ARGS: .\qpep.exe -apiport 0
22:15:56.478781 {
 "AckElicitingPacketsBeforeAck": 10,
 "AckDecimationDenominator": 4,
 "InitialCongestionWindowPackets": 4,
 "MultiStream": true,
 "VarAckDelay": 0.25,
 "MaxAckDelay": 25,
 "MinReceivedBeforeAckDecimation": 100,
 "ClientFlag": false,
 "GatewayIP": "198.18.0.254",
 "GatewayPort": 443,
 "GatewayAPIPort": 0,
 "ListenIP": "127.0.0.1",
 "ListenPort": 9443,
 "WinDivertThreads": 1,
 "Verbose": false
}
22:15:56.480873 Running Server
22:15:56.481388 Invalid parameter api port as port [1-65536]: 0
22:15:56.482802 PANIC: configuration was unsuccessfull
22:15:56.481388 Opening API Server on: 127.0.0.1:0
goroutine 6 [running]:
runtime/debug.Stack(0xc00005c050, 0x2, 0xc000099d40)
        c:/home/dev/go_1.16.1/src/runtime/debug/stack.go:24 +0xa5
runtime/debug.PrintStack()
        c:/home/dev/go_1.16.1/src/runtime/debug/stack.go:16 +0x29
github.com/parvit/qpep/server.RunServer.func1(0xc00004eeb0)
        C:/home/dev/src/github.com/parvit/qpep-faster/server/server.go:47 +0xca
panic(0x1017f00, 0xc00004ec30)
        c:/home/dev/go_1.16.1/src/runtime/panic.go:965 +0x1c7
github.com/parvit/qpep/shared.AssertParamPort(...)
        C:/home/dev/src/github.com/parvit/qpep-faster/shared/params_validation.go:19
github.com/parvit/qpep/server.validateConfiguration(0x0, 0x0)
        C:/home/dev/src/github.com/parvit/qpep-faster/server/server.go:246 +0x2f9
github.com/parvit/qpep/server.RunServer(0x111c578, 0xc00002c780, 0xc00004eeb0)
        C:/home/dev/src/github.com/parvit/qpep-faster/server/server.go:56 +0x77
created by main.runAsServer
        C:/home/dev/src/github.com/parvit/qpep-faster/main.go:99 +0x9e
22:15:56.501325 Shutdown...
22:15:56.502971 [0000] Windivert engine must first be initialized
22:15:56.501840 Error running API server: http: Server closed
22:15:56.504062 Closed API Server
22:15:56.504062 1
22:15:57.507317 Exiting...
```

Which should be sufficient to cover most user error configurations that can be catched.

Please test and review, if there's positive feedback i'll merge.
